### PR TITLE
Updated for Swift 3 and added the ability to strip UISupportedDevices

### DIFF
--- a/AppSigner/AppDelegate.swift
+++ b/AppSigner/AppDelegate.swift
@@ -12,40 +12,40 @@ import Cocoa
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var mainView: MainView!
-    let fileManager = NSFileManager.defaultManager()
+    let fileManager = FileManager.default
     
     
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
-        try? fileManager.removeItemAtPath(Log.logName)
+        try? fileManager.removeItem(atPath: Log.logName)
     }
     
-    func applicationShouldTerminateAfterLastWindowClosed(sender: NSApplication) -> Bool {
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
     }
-    @IBAction func fixSigning(sender: NSMenuItem) {
+    @IBAction func fixSigning(_ sender: NSMenuItem) {
         if let tempFolder = mainView.makeTempFolder() {
             iASShared.fixSigning(tempFolder)
-            try? fileManager.removeItemAtPath(tempFolder)
+            try? fileManager.removeItem(atPath: tempFolder)
             mainView.populateCodesigningCerts()
         }
     }
 
-    @IBAction func nsMenuLinkClick(sender: NSMenuLink) {
-        NSWorkspace.sharedWorkspace().openURL(NSURL(string: sender.url!)!)
+    @IBAction func nsMenuLinkClick(_ sender: NSMenuLink) {
+        NSWorkspace.shared().open(URL(string: sender.url!)!)
     }
-    @IBAction func viewLog(sender: AnyObject) {
-        NSWorkspace.sharedWorkspace().openFile(Log.logName)
+    @IBAction func viewLog(_ sender: AnyObject) {
+        NSWorkspace.shared().openFile(Log.logName)
     }
-    @IBAction func checkForUpdates(sender: NSMenuItem) {
+    @IBAction func checkForUpdates(_ sender: NSMenuItem) {
         UpdatesController.checkForUpdate(forceShow: true)
-        func updateCheckStatus(status: Bool, data: NSData?, response: NSURLResponse?, error: NSError?){
+        func updateCheckStatus(_ status: Bool, data: Data?, response: URLResponse?, error: NSError?){
             if status == false {
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     let alert = NSAlert()
                     
                     

--- a/AppSigner/Application.xib
+++ b/AppSigner/Application.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -118,16 +119,16 @@
         <window title="iOS App Signer" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" unifiedTitleAndToolbar="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="550" height="181"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1080"/>
+            <rect key="contentRect" x="196" y="240" width="550" height="209"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <value key="minSize" type="size" width="550" height="181"/>
             <value key="maxSize" type="size" width="9999" height="181"/>
             <view key="contentView" id="se5-gp-TjO" customClass="MainView" customModule="iOS_App_Signer" customModuleProvider="target">
-                <rect key="frame" x="0.0" y="0.0" width="550" height="181"/>
+                <rect key="frame" x="0.0" y="0.0" width="550" height="209"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YSK-IJ-CeM">
-                        <rect key="frame" x="136" y="63" width="406" height="22"/>
+                        <rect key="frame" x="136" y="91" width="406" height="22"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="This is where you would change the application identifier" drawsBackground="YES" id="395-ue-2J0">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -135,7 +136,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YJU-Yl-45B">
-                        <rect key="frame" x="6" y="124" width="124" height="17"/>
+                        <rect key="frame" x="6" y="152" width="124" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Signing Certificate:" id="WUr-cp-F8p">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -143,7 +144,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tPN-Hd-sKi">
-                        <rect key="frame" x="6" y="66" width="124" height="17"/>
+                        <rect key="frame" x="6" y="94" width="124" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="New Application ID:" id="WPy-tB-bJ4">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -151,25 +152,15 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Sa-9c-2wd">
-                        <rect key="frame" x="6" y="154" width="124" height="17"/>
+                        <rect key="frame" x="6" y="182" width="124" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Input File:" id="ZCT-YD-39f">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Q7q-HU-46D">
-                        <rect key="frame" x="478" y="27" width="70" height="32"/>
-                        <buttonCell key="cell" type="push" title="Start" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ox8-ir-pSO">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="doSign:" target="se5-gp-TjO" id="xHC-0Z-wyX"/>
-                        </connections>
-                    </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jID-Ce-koR">
-                        <rect key="frame" x="463" y="145" width="85" height="32"/>
+                        <rect key="frame" x="463" y="173" width="85" height="32"/>
                         <buttonCell key="cell" type="push" title="Browse" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="G75-5L-8SZ">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -179,7 +170,7 @@
                         </connections>
                     </button>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aVt-Sy-tta">
-                        <rect key="frame" x="134" y="119" width="411" height="26"/>
+                        <rect key="frame" x="134" y="147" width="411" height="26"/>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="Yf9-38-1CN">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="menu"/>
@@ -196,7 +187,7 @@
                         </connections>
                     </popUpButton>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4SO-6J-jzo">
-                        <rect key="frame" x="134" y="90" width="411" height="26"/>
+                        <rect key="frame" x="134" y="118" width="411" height="26"/>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="xup-Rd-N3A">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="menu"/>
@@ -213,7 +204,7 @@
                         </connections>
                     </popUpButton>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DTS-Xr-BlP">
-                        <rect key="frame" x="6" y="95" width="124" height="17"/>
+                        <rect key="frame" x="6" y="123" width="124" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Provisioning Profile:" id="aX0-sJ-gW1">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -221,7 +212,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GdX-jd-F08">
-                        <rect key="frame" x="136" y="151" width="325" height="22"/>
+                        <rect key="frame" x="136" y="179" width="325" height="22"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="File path or URL accepted" drawsBackground="YES" usesSingleLineMode="YES" id="fri-IK-93r">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -229,7 +220,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qJN-16-XSx">
-                        <rect key="frame" x="136" y="33" width="340" height="22"/>
+                        <rect key="frame" x="136" y="61" width="406" height="22"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="This changes the app title on the home screen" drawsBackground="YES" id="KLQ-qo-m8y">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -237,7 +228,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zay-Rf-RG2">
-                        <rect key="frame" x="6" y="36" width="124" height="17"/>
+                        <rect key="frame" x="6" y="64" width="124" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="App Display Name:" id="pA5-gE-hQU">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -276,6 +267,23 @@
                             <action selector="statusLabelClick:" target="se5-gp-TjO" id="pH3-Yf-e06"/>
                         </connections>
                     </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Q7q-HU-46D">
+                        <rect key="frame" x="478" y="25" width="70" height="32"/>
+                        <buttonCell key="cell" type="push" title="Start" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ox8-ir-pSO">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="doSign:" target="se5-gp-TjO" id="xHC-0Z-wyX"/>
+                        </connections>
+                    </button>
+                    <button translatesAutoresizingMaskIntoConstraints="NO" id="3yD-WS-Xpj">
+                        <rect key="frame" x="6" y="37" width="223" height="18"/>
+                        <buttonCell key="cell" type="check" title="Enable installation on any device." bezelStyle="regularSquare" imagePosition="left" inset="2" id="FOg-bw-2nS">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstItem="Zay-Rf-RG2" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="0jB-Rw-Lih"/>
@@ -286,20 +294,22 @@
                     <constraint firstItem="4Sa-9c-2wd" firstAttribute="width" secondItem="YJU-Yl-45B" secondAttribute="width" id="8T7-Mo-JRF"/>
                     <constraint firstAttribute="trailing" secondItem="jID-Ce-koR" secondAttribute="trailing" constant="8" id="9dv-Y0-YhM"/>
                     <constraint firstItem="aVt-Sy-tta" firstAttribute="centerY" secondItem="YJU-Yl-45B" secondAttribute="centerY" id="9eT-9n-hbW"/>
+                    <constraint firstAttribute="trailing" secondItem="Q7q-HU-46D" secondAttribute="trailing" constant="8" id="Arl-mo-BHJ"/>
                     <constraint firstItem="9a5-Oe-N79" firstAttribute="leading" secondItem="zUI-5c-Yv6" secondAttribute="trailing" constant="6" id="EbS-UA-l9f"/>
                     <constraint firstItem="4SO-6J-jzo" firstAttribute="top" secondItem="aVt-Sy-tta" secondAttribute="bottom" constant="8" id="KYH-G8-jZN"/>
                     <constraint firstAttribute="trailing" secondItem="ldw-vd-vcX" secondAttribute="trailing" constant="4" id="Kux-fL-4Bw"/>
                     <constraint firstItem="aVt-Sy-tta" firstAttribute="leading" secondItem="YJU-Yl-45B" secondAttribute="trailing" constant="8" id="NQP-Rj-e4f"/>
                     <constraint firstAttribute="trailing" secondItem="9a5-Oe-N79" secondAttribute="trailing" constant="6" id="Okg-LD-ks1"/>
                     <constraint firstItem="4Sa-9c-2wd" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="Osz-hK-Auj"/>
+                    <constraint firstItem="qJN-16-XSx" firstAttribute="trailing" secondItem="Q7q-HU-46D" secondAttribute="trailing" id="PsY-8o-h0a"/>
                     <constraint firstItem="qJN-16-XSx" firstAttribute="top" secondItem="YSK-IJ-CeM" secondAttribute="bottom" constant="8" id="QMZ-P1-jn1"/>
                     <constraint firstItem="GdX-jd-F08" firstAttribute="centerY" secondItem="4Sa-9c-2wd" secondAttribute="centerY" id="Qfi-gW-YMQ"/>
-                    <constraint firstItem="qJN-16-XSx" firstAttribute="leading" secondItem="Zay-Rf-RG2" secondAttribute="trailing" constant="8" id="R2C-LQ-K7X"/>
                     <constraint firstItem="GdX-jd-F08" firstAttribute="leading" secondItem="4Sa-9c-2wd" secondAttribute="trailing" constant="8" id="SAk-3c-sQS"/>
                     <constraint firstItem="YSK-IJ-CeM" firstAttribute="leading" secondItem="tPN-Hd-sKi" secondAttribute="trailing" constant="8" id="WHV-Hr-P3M"/>
                     <constraint firstItem="YSK-IJ-CeM" firstAttribute="centerY" secondItem="tPN-Hd-sKi" secondAttribute="centerY" id="WKY-eZ-IAc"/>
-                    <constraint firstItem="Q7q-HU-46D" firstAttribute="centerY" secondItem="qJN-16-XSx" secondAttribute="centerY" id="WLS-rG-4aj"/>
                     <constraint firstItem="Zay-Rf-RG2" firstAttribute="width" secondItem="YJU-Yl-45B" secondAttribute="width" id="XF6-SW-NyI"/>
+                    <constraint firstItem="3yD-WS-Xpj" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="Zrf-bk-P2g"/>
+                    <constraint firstItem="3yD-WS-Xpj" firstAttribute="top" secondItem="qJN-16-XSx" secondAttribute="bottom" constant="8" symbolic="YES" id="bWf-QY-mFO"/>
                     <constraint firstItem="ldw-vd-vcX" firstAttribute="centerY" secondItem="w01-jO-HKq" secondAttribute="centerY" id="bn9-2F-BTD"/>
                     <constraint firstItem="4SO-6J-jzo" firstAttribute="leading" secondItem="DTS-Xr-BlP" secondAttribute="trailing" constant="8" id="cf9-FE-lfR"/>
                     <constraint firstItem="zUI-5c-Yv6" firstAttribute="leading" secondItem="ldw-vd-vcX" secondAttribute="leading" id="ctN-hc-gnn"/>
@@ -312,21 +322,24 @@
                     <constraint firstItem="zUI-5c-Yv6" firstAttribute="top" secondItem="ldw-vd-vcX" secondAttribute="top" id="kb8-zN-dxO"/>
                     <constraint firstItem="DTS-Xr-BlP" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="klL-Iw-dlK"/>
                     <constraint firstItem="GdX-jd-F08" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="8" id="lMW-sx-FKT"/>
+                    <constraint firstItem="Q7q-HU-46D" firstAttribute="top" secondItem="qJN-16-XSx" secondAttribute="bottom" constant="8" id="mPP-zh-oYq"/>
                     <constraint firstItem="GdX-jd-F08" firstAttribute="centerY" secondItem="4Sa-9c-2wd" secondAttribute="centerY" id="mu3-qQ-mca"/>
                     <constraint firstItem="aVt-Sy-tta" firstAttribute="top" secondItem="GdX-jd-F08" secondAttribute="bottom" constant="8" id="nqL-DD-iYW"/>
                     <constraint firstItem="jID-Ce-koR" firstAttribute="leading" secondItem="GdX-jd-F08" secondAttribute="trailing" constant="8" id="qBV-8H-UfW"/>
                     <constraint firstItem="tPN-Hd-sKi" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="qHV-nh-CNG"/>
+                    <constraint firstItem="qJN-16-XSx" firstAttribute="leading" secondItem="YSK-IJ-CeM" secondAttribute="leading" id="qSw-W8-tUN"/>
                     <constraint firstAttribute="trailing" secondItem="aVt-Sy-tta" secondAttribute="trailing" constant="8" id="qeI-cR-hAs"/>
                     <constraint firstItem="4SO-6J-jzo" firstAttribute="centerY" secondItem="DTS-Xr-BlP" secondAttribute="centerY" id="tLy-xL-vVc"/>
-                    <constraint firstItem="Q7q-HU-46D" firstAttribute="leading" secondItem="qJN-16-XSx" secondAttribute="trailing" constant="8" id="vx4-Ox-PVw"/>
                     <constraint firstAttribute="bottom" secondItem="w01-jO-HKq" secondAttribute="bottom" id="wJb-cd-f6h"/>
                     <constraint firstItem="w01-jO-HKq" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="y8T-mF-uol"/>
                     <constraint firstAttribute="trailing" secondItem="4SO-6J-jzo" secondAttribute="trailing" constant="8" id="z4T-fq-3QX"/>
                     <constraint firstAttribute="trailing" secondItem="w01-jO-HKq" secondAttribute="trailing" id="zN5-l4-HSj"/>
+                    <constraint firstItem="3yD-WS-Xpj" firstAttribute="top" secondItem="qJN-16-XSx" secondAttribute="bottom" constant="8" id="zo4-85-qGl"/>
                 </constraints>
                 <connections>
                     <outlet property="BrowseButton" destination="jID-Ce-koR" id="NWk-QW-2ha"/>
                     <outlet property="CodesigningCertsPopup" destination="aVt-Sy-tta" id="Agf-8A-13v"/>
+                    <outlet property="DeviceSupportCheck" destination="3yD-WS-Xpj" id="q73-Hp-Fe9"/>
                     <outlet property="InputFileText" destination="GdX-jd-F08" id="7p7-B8-sHq"/>
                     <outlet property="NewApplicationIDTextField" destination="YSK-IJ-CeM" id="G8I-Gb-Khr"/>
                     <outlet property="ProvisioningProfilesPopup" destination="4SO-6J-jzo" id="nfx-Js-6Gt"/>
@@ -337,7 +350,7 @@
                 </connections>
             </view>
             <contentBorderThickness minY="25"/>
-            <point key="canvasLocation" x="345" y="269.5"/>
+            <point key="canvasLocation" x="345" y="284"/>
         </window>
     </objects>
 </document>

--- a/AppSigner/Classes/iASShared.swift
+++ b/AppSigner/Classes/iASShared.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 class iASShared {
-    static func fixSigning(tempFolder: String){
-        let script = "do shell script \"/bin/bash \\\"\(NSBundle.mainBundle().pathForResource("fix-wwdr", ofType: "sh")!)\\\"\" with administrator privileges"
+    static func fixSigning(_ tempFolder: String){
+        let script = "do shell script \"/bin/bash \\\"\(Bundle.main.path(forResource: "fix-wwdr", ofType: "sh")!)\\\"\" with administrator privileges"
         NSAppleScript(source: script)?.executeAndReturnError(nil)
         //https://developer.apple.com/certificationauthority/AppleWWDRCA.cer
         return

--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSessionDownloadDelegate {
+class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDownloadDelegate {
     
     //MARK: IBOutlets
     @IBOutlet var ProvisioningProfilesPopup: NSPopUpButton!
@@ -33,9 +33,9 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     var NibLoaded = false
     
     //MARK: Constants
-    let defaults = NSUserDefaults()
-    let fileManager = NSFileManager.defaultManager()
-    let bundleID = NSBundle.mainBundle().bundleIdentifier
+    let defaults = UserDefaults()
+    let fileManager = FileManager.default
+    let bundleID = Bundle.main.bundleIdentifier
     let arPath = "/usr/bin/ar"
     let mktempPath = "/usr/bin/mktemp"
     let tarPath = "/usr/bin/tar"
@@ -51,14 +51,14 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     var urlFileTypes: [String] = ["ipa","deb"]
     var fileTypeIsOk = false
     
-    func fileDropped(filename: String){
-        switch(filename.pathExtension.lowercaseString){
+    func fileDropped(_ filename: String){
+        switch(filename.pathExtension.lowercased()){
         case "ipa", "deb", "app", "xcarchive":
             InputFileText.stringValue = filename
             break
             
         case "mobileprovision":
-            ProvisioningProfilesPopup.selectItemAtIndex(1)
+            ProvisioningProfilesPopup.selectItem(at: 1)
             checkProfileID(ProvisioningProfile(filename: filename))
             break
         default: break
@@ -66,31 +66,31 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
     }
     
-    func urlDropped(url: NSURL){
+    func urlDropped(_ url: URL){
         InputFileText.stringValue = url.absoluteString
     }
     
-    override func draggingEntered(sender: NSDraggingInfo) -> NSDragOperation {
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         if checkExtension(sender) == true {
             self.fileTypeIsOk = true
-            return .Copy
+            return .copy
         } else {
             self.fileTypeIsOk = false
-            return .None
+            return NSDragOperation()
         }
     }
     
-    override func draggingUpdated(sender: NSDraggingInfo) -> NSDragOperation {
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
         if self.fileTypeIsOk {
-            return .Copy
+            return .copy
         } else {
-            return .None
+            return NSDragOperation()
         }
     }
     
-    override func performDragOperation(sender: NSDraggingInfo) -> Bool {
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         let pasteboard = sender.draggingPasteboard()
-        if let board = pasteboard.propertyListForType("NSFilenamesPboardType") as? NSArray {
+        if let board = pasteboard.propertyList(forType: "NSFilenamesPboardType") as? NSArray {
             if let filePath = board[0] as? String {
                 
                 fileDropped(filePath)
@@ -99,7 +99,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
         if let types = pasteboard.types {
             if types.contains(NSURLPboardType) {
-                if let url = NSURL(fromPasteboard: pasteboard) {
+                if let url = NSURL(from: pasteboard) as? URL {
                     urlDropped(url)
                 }
             }
@@ -107,16 +107,15 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         return false
     }
     
-    func checkExtension(drag: NSDraggingInfo) -> Bool {
-        if let board = drag.draggingPasteboard().propertyListForType("NSFilenamesPboardType") as? NSArray,
+    func checkExtension(_ drag: NSDraggingInfo) -> Bool {
+        if let board = drag.draggingPasteboard().propertyList(forType: "NSFilenamesPboardType") as? NSArray,
             let path = board[0] as? String {
-                return self.fileTypes.contains(path.pathExtension.lowercaseString)
+                return self.fileTypes.contains(path.pathExtension.lowercased())
         }
         if let types = drag.draggingPasteboard().types {
             if types.contains(NSURLPboardType) {
-                if let url = NSURL(fromPasteboard: drag.draggingPasteboard()),
-                    suffix = url.pathExtension {
-                        return self.urlFileTypes.contains(suffix.lowercaseString)
+                if let url = NSURL(from: drag.draggingPasteboard()) as? URL, url.pathExtension.characters.count > 0{
+                        return self.urlFileTypes.contains(url.pathExtension.lowercased())
                 }
             }
         }
@@ -127,11 +126,11 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        registerForDraggedTypes([NSFilenamesPboardType, NSURLPboardType])
+        register(forDraggedTypes: [NSFilenamesPboardType, NSURLPboardType])
     }
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        registerForDraggedTypes([NSFilenamesPboardType, NSURLPboardType])
+        register(forDraggedTypes: [NSFilenamesPboardType, NSURLPboardType])
     }
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -142,10 +141,10 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             // Do any additional setup after loading the view.
             populateProvisioningProfiles()
             populateCodesigningCerts()
-            if let defaultCert = defaults.stringForKey("signingCertificate") {
+            if let defaultCert = defaults.string(forKey: "signingCertificate") {
                 if codesigningCerts.contains(defaultCert) {
                     Log.write("Loaded Codesigning Certificate from Defaults: \(defaultCert)")
-                    CodesigningCertsPopup.selectItemWithTitle(defaultCert)
+                    CodesigningCertsPopup.selectItem(withTitle: defaultCert)
                 }
             }
             setStatus("Ready")
@@ -154,53 +153,53 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     }
     
     func makeTempFolder()->String?{
-        let tempTask = NSTask().execute(mktempPath, workingDirectory: nil, arguments: ["-d","-t",bundleID!])
+        let tempTask = Process().execute(mktempPath, workingDirectory: nil, arguments: ["-d","-t",bundleID!])
         if tempTask.status != 0 {
             return nil
         }
-        return tempTask.output.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        return tempTask.output.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
     }
     
-    func setStatus(status: String){
+    func setStatus(_ status: String){
         Log.write(status)
         StatusLabel.stringValue = status
     }
     
     func populateProvisioningProfiles(){
         let zeroWidthSpace = "​"
-        self.provisioningProfiles = ProvisioningProfile.getProfiles().sort {
+        self.provisioningProfiles = ProvisioningProfile.getProfiles().sorted {
             ($0.name == $1.name && $0.created.timeIntervalSince1970 > $1.created.timeIntervalSince1970) || $0.name < $1.name
         }
         setStatus("Found \(provisioningProfiles.count) Provisioning Profile\(provisioningProfiles.count>1 || provisioningProfiles.count<1 ? "s":"")")
         ProvisioningProfilesPopup.removeAllItems()
-        ProvisioningProfilesPopup.addItemsWithTitles([
+        ProvisioningProfilesPopup.addItems(withTitles: [
             "Re-Sign Only",
             "Choose Custom File",
             "––––––––––––––––––––––"
         ])
-        let formatter = NSDateFormatter()
-        formatter.dateStyle = .ShortStyle
-        formatter.timeStyle = .MediumStyle
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .medium
         var newProfiles: [ProvisioningProfile] = []
         var zeroWidthPadding: String = ""
         for profile in provisioningProfiles {
             zeroWidthPadding = "\(zeroWidthPadding)\(zeroWidthSpace)"
-            if profile.expires.timeIntervalSince1970 > NSDate().timeIntervalSince1970 {
+            if profile.expires.timeIntervalSince1970 > Date().timeIntervalSince1970 {
                 newProfiles.append(profile)
                 
-                ProvisioningProfilesPopup.addItemWithTitle("\(profile.name)\(zeroWidthPadding) (\(profile.teamID))")
+                ProvisioningProfilesPopup.addItem(withTitle: "\(profile.name)\(zeroWidthPadding) (\(profile.teamID))")
                 
                 let toolTipItems = [
                     "\(profile.name)",
                     "",
                     "Team ID: \(profile.teamID)",
-                    "Created: \(formatter.stringFromDate(profile.created))",
-                    "Expires: \(formatter.stringFromDate(profile.expires))"
+                    "Created: \(formatter.string(from: profile.created as Date))",
+                    "Expires: \(formatter.string(from: profile.expires as Date))"
                 ]
-                ProvisioningProfilesPopup.lastItem!.toolTip = toolTipItems.joinWithSeparator("\n")
-                setStatus("Added profile \(profile.appID), expires (\(formatter.stringFromDate(profile.expires)))")
+                ProvisioningProfilesPopup.lastItem!.toolTip = toolTipItems.joined(separator: "\n")
+                setStatus("Added profile \(profile.appID), expires (\(formatter.string(from: profile.expires as Date)))")
             } else {
-                setStatus("Skipped profile \(profile.appID), expired (\(formatter.stringFromDate(profile.expires)))")
+                setStatus("Skipped profile \(profile.appID), expired (\(formatter.string(from: profile.expires as Date)))")
             }
         }
         self.provisioningProfiles = newProfiles
@@ -209,15 +208,15 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     
     func getCodesigningCerts() -> [String] {
         var output: [String] = []
-        let securityResult = NSTask().execute(securityPath, workingDirectory: nil, arguments: ["find-identity","-v","-p","codesigning"])
+        let securityResult = Process().execute(securityPath, workingDirectory: nil, arguments: ["find-identity","-v","-p","codesigning"])
         if securityResult.output.characters.count < 1 {
             return output
         }
-        let rawResult = securityResult.output.componentsSeparatedByString("\"")
+        let rawResult = securityResult.output.components(separatedBy: "\"")
         
         var index: Int
         
-        for index in 0.stride(through: rawResult.count - 2, by: 2) {
+        for index in stride(from: 0, through: rawResult.count - 2, by: 2) {
             if !(rawResult.count - 1 < index + 1) {
                 output.append(rawResult[index+1])
             }
@@ -229,12 +228,12 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         let alert = NSAlert()
         alert.messageText = "No codesigning certificates found"
         alert.informativeText = "I can attempt to fix this automatically, would you like me to try?"
-        alert.addButtonWithTitle("Yes")
-        alert.addButtonWithTitle("No")
+        alert.addButton(withTitle: "Yes")
+        alert.addButton(withTitle: "No")
         if alert.runModal() == NSAlertFirstButtonReturn {
             if let tempFolder = makeTempFolder() {
                 iASShared.fixSigning(tempFolder)
-                try? fileManager.removeItemAtPath(tempFolder)
+                try? fileManager.removeItem(atPath: tempFolder)
                 populateCodesigningCerts()
             }
         }
@@ -247,7 +246,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         setStatus("Found \(self.codesigningCerts.count) Codesigning Certificate\(self.codesigningCerts.count>1 || self.codesigningCerts.count<1 ? "s":"")")
         if self.codesigningCerts.count > 0 {
             for cert in self.codesigningCerts {
-                CodesigningCertsPopup.addItemWithTitle(cert)
+                CodesigningCertsPopup.addItem(withTitle: cert)
                 setStatus("Added signing certificate \"\(cert)\"")
             }
         } else {
@@ -256,95 +255,96 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         
     }
     
-    func checkProfileID(profile: ProvisioningProfile?){
+    func checkProfileID(_ profile: ProvisioningProfile?){
         if let profile = profile {
             self.profileFilename = profile.filename
             setStatus("Selected provisioning profile \(profile.appID)")
-            if profile.expires.timeIntervalSince1970 < NSDate().timeIntervalSince1970 {
-                ProvisioningProfilesPopup.selectItemAtIndex(0)
+            if profile.expires.timeIntervalSince1970 < Date().timeIntervalSince1970 {
+                ProvisioningProfilesPopup.selectItem(at: 0)
                 setStatus("Provisioning profile expired")
                 chooseProvisioningProfile(ProvisioningProfilesPopup)
             }
-            if profile.appID.characters.indexOf("*") == nil {
+            if profile.appID.characters.index(of: "*") == nil {
                 // Not a wildcard profile
                 NewApplicationIDTextField.stringValue = profile.appID
-                NewApplicationIDTextField.enabled = false
+                NewApplicationIDTextField.isEnabled = false
             } else {
                 // Wildcard profile
-                if NewApplicationIDTextField.enabled == false {
+                if NewApplicationIDTextField.isEnabled == false {
                     NewApplicationIDTextField.stringValue = ""
-                    NewApplicationIDTextField.enabled = true
+                    NewApplicationIDTextField.isEnabled = true
                 }
             }
         } else {
-            ProvisioningProfilesPopup.selectItemAtIndex(0)
+            ProvisioningProfilesPopup.selectItem(at: 0)
             setStatus("Invalid provisioning profile")
             chooseProvisioningProfile(ProvisioningProfilesPopup)
         }
     }
     
-    func controlsEnabled(enabled: Bool){
+    func controlsEnabled(_ enabled: Bool){
         if(enabled){
-            InputFileText.enabled = true
-            BrowseButton.enabled = true
-            ProvisioningProfilesPopup.enabled = true
-            CodesigningCertsPopup.enabled = true
-            NewApplicationIDTextField.enabled = ReEnableNewApplicationID
+            InputFileText.isEnabled = true
+            BrowseButton.isEnabled = true
+            ProvisioningProfilesPopup.isEnabled = true
+            CodesigningCertsPopup.isEnabled = true
+            NewApplicationIDTextField.isEnabled = ReEnableNewApplicationID
             NewApplicationIDTextField.stringValue = PreviousNewApplicationID
-            StartButton.enabled = true
-            appDisplayName.enabled = true
+            StartButton.isEnabled = true
+            appDisplayName.isEnabled = true
         } else {
             // Backup previous values
             PreviousNewApplicationID = NewApplicationIDTextField.stringValue
-            ReEnableNewApplicationID = NewApplicationIDTextField.enabled
+            ReEnableNewApplicationID = NewApplicationIDTextField.isEnabled
             
-            InputFileText.enabled = false
-            BrowseButton.enabled = false
-            ProvisioningProfilesPopup.enabled = false
-            CodesigningCertsPopup.enabled = false
-            NewApplicationIDTextField.enabled = false
-            StartButton.enabled = false
-            appDisplayName.enabled = false
+            InputFileText.isEnabled = false
+            BrowseButton.isEnabled = false
+            ProvisioningProfilesPopup.isEnabled = false
+            CodesigningCertsPopup.isEnabled = false
+            NewApplicationIDTextField.isEnabled = false
+            StartButton.isEnabled = false
+            appDisplayName.isEnabled = false
         }
     }
     
-    func recursiveDirectorySearch(path: String, extensions: [String], found: ((file: String) -> Void)){
+    func recursiveDirectorySearch(_ path: String, extensions: [String], found: ((_ file: String) -> Void)){
         
-        if let files = try? fileManager.contentsOfDirectoryAtPath(path) {
+        if let files = try? fileManager.contentsOfDirectory(atPath: path) {
             var isDirectory: ObjCBool = true
             
             for file in files {
                 let currentFile = path.stringByAppendingPathComponent(file)
-                fileManager.fileExistsAtPath(currentFile, isDirectory: &isDirectory)
-                if isDirectory {
+                fileManager.fileExists(atPath: currentFile, isDirectory: &isDirectory)
+                if isDirectory.boolValue {
                     recursiveDirectorySearch(currentFile, extensions: extensions, found: found)
                 }
                 if extensions.contains(file.pathExtension) {
-                    found(file: currentFile)
+                    found(currentFile)
                 }
                 
             }
         }
     }
     
-    func unzip(inputFile: String, outputPath: String)->AppSignerTaskOutput {
-        return NSTask().execute(unzipPath, workingDirectory: nil, arguments: ["-q",inputFile,"-d",outputPath])
+    func unzip(_ inputFile: String, outputPath: String)->AppSignerTaskOutput {
+        return Process().execute(unzipPath, workingDirectory: nil, arguments: ["-q",inputFile,"-d",outputPath])
     }
-    func zip(inputPath: String, outputFile: String)->AppSignerTaskOutput {
-        return NSTask().execute(zipPath, workingDirectory: inputPath, arguments: ["-qry", outputFile, "."])
+    func zip(_ inputPath: String, outputFile: String)->AppSignerTaskOutput {
+        return Process().execute(zipPath, workingDirectory: inputPath, arguments: ["-qry", outputFile, "."])
     }
     
-    func cleanup(tempFolder: String){
+    func cleanup(_ tempFolder: String){
         do {
             Log.write("Deleting: \(tempFolder)")
-            try fileManager.removeItemAtPath(tempFolder)
+            try fileManager.removeItem(atPath: tempFolder)
         } catch let error as NSError {
             setStatus("Unable to delete temp folder")
             Log.write(error.localizedDescription)
+        } catch {
         }
         controlsEnabled(true)
     }
-    func bytesToSmallestSi(size: Double) -> String {
+    func bytesToSmallestSi(_ size: Double) -> String {
         let prefixes = ["","K","M","G","T","P","E","Z","Y"]
         for i in 1...6 {
             let nextUnit = pow(1024.00, Double(i+1))
@@ -356,8 +356,8 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
         return "\(size)B"
     }
-    func getPlistKey(plist: String, keyName: String)->String? {
-        let currTask = NSTask().execute(defaultsPath, workingDirectory: nil, arguments: ["read", plist, keyName])
+    func getPlistKey(_ plist: String, keyName: String)->String? {
+        let currTask = Process().execute(defaultsPath, workingDirectory: nil, arguments: ["read", plist, keyName])
         if currTask.status == 0 {
             return String(currTask.output.characters.dropLast())
         } else {
@@ -365,8 +365,8 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
     }
     
-    func setPlistKey(plist: String, keyName: String, value: String)->AppSignerTaskOutput {
-        return NSTask().execute(defaultsPath, workingDirectory: nil, arguments: ["write", plist, keyName, value])
+    func setPlistKey(_ plist: String, keyName: String, value: String)->AppSignerTaskOutput {
+        return Process().execute(defaultsPath, workingDirectory: nil, arguments: ["write", plist, keyName, value])
     }
     
     //MARK: NSURL Delegate
@@ -374,11 +374,11 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     var downloadError: NSError?
     var downloadPath: String!
     
-    func URLSession(session: NSURLSession, downloadTask: NSURLSessionDownloadTask, didFinishDownloadingToURL location: NSURL) {
-        downloadError = downloadTask.error
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        downloadError = downloadTask.error as NSError?
         if downloadError == nil {
             do {
-                try fileManager.moveItemAtURL(location, toURL: NSURL(fileURLWithPath: downloadPath))
+                try fileManager.moveItem(at: location, to: URL(fileURLWithPath: downloadPath))
             } catch let error as NSError {
                 setStatus("Unable to move downloaded file")
                 Log.write(error.localizedDescription)
@@ -389,7 +389,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         downloadProgress.stopAnimation(nil)
     }
     
-    func URLSession(session: NSURLSession, downloadTask: NSURLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         
         //StatusLabel.stringValue = "Downloading file: \(bytesToSmallestSi(Double(totalBytesWritten))) / \(bytesToSmallestSi(Double(totalBytesExpectedToWrite)))"
         let percentDownloaded = (Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)) * 100
@@ -397,13 +397,13 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
     }
     
     //MARK: Codesigning
-    func codeSign(file: String, certificate: String, entitlements: String?,before:((file: String, certificate: String, entitlements: String?)->Void)?, after: ((file: String, certificate: String, entitlements: String?, codesignTask: AppSignerTaskOutput)->Void)?)->AppSignerTaskOutput{
+    func codeSign(_ file: String, certificate: String, entitlements: String?,before:((_ file: String, _ certificate: String, _ entitlements: String?)->Void)?, after: ((_ file: String, _ certificate: String, _ entitlements: String?, _ codesignTask: AppSignerTaskOutput)->Void)?)->AppSignerTaskOutput{
         
         let useEntitlements: Bool = ({
             if entitlements == nil {
                 return false
             } else {
-                if fileManager.fileExistsAtPath(entitlements!) {
+                if fileManager.fileExists(atPath: entitlements!) {
                     return true
                 } else {
                     return false
@@ -412,29 +412,29 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         })()
         
         if let beforeFunc = before {
-            beforeFunc(file: file, certificate: certificate, entitlements: entitlements)
+            beforeFunc(file, certificate, entitlements)
         }
         var arguments = ["-vvv","-fs",certificate,"--no-strict"]
         if useEntitlements {
             arguments.append("--entitlements=\(entitlements!)")
         }
         arguments.append(file)
-        let codesignTask = NSTask().execute(codesignPath, workingDirectory: nil, arguments: arguments)
+        let codesignTask = Process().execute(codesignPath, workingDirectory: nil, arguments: arguments)
         if let afterFunc = after {
-            afterFunc(file: file, certificate: certificate, entitlements: entitlements, codesignTask: codesignTask)
+            afterFunc(file, certificate, entitlements, codesignTask)
         }
         return codesignTask
     }
-    func testSigning(certificate: String, tempFolder: String )->Bool? {
+    func testSigning(_ certificate: String, tempFolder: String )->Bool? {
         let codesignTempFile = tempFolder.stringByAppendingPathComponent("test-sign")
         
         // Copy our binary to the temp folder to use for testing.
-        let path = NSProcessInfo.processInfo().arguments[0]
-        if (try? fileManager.copyItemAtPath(path, toPath: codesignTempFile)) != nil {
+        let path = ProcessInfo.processInfo.arguments[0]
+        if (try? fileManager.copyItem(atPath: path, toPath: codesignTempFile)) != nil {
             codeSign(codesignTempFile, certificate: certificate, entitlements: nil, before: nil, after: nil)
             
-            let verificationTask = NSTask().execute(codesignPath, workingDirectory: nil, arguments: ["-v",codesignTempFile])
-            try? fileManager.removeItemAtPath(codesignTempFile)
+            let verificationTask = Process().execute(codesignPath, workingDirectory: nil, arguments: ["-v",codesignTempFile])
+            try? fileManager.removeItem(atPath: codesignTempFile)
             if verificationTask.status == 0 {
                 return true
             } else {
@@ -454,8 +454,8 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         saveDialog.allowedFileTypes = ["ipa"]
         saveDialog.nameFieldStringValue = InputFileText.stringValue.lastPathComponent.stringByDeletingPathExtension
         if saveDialog.runModal() == NSFileHandlingPanelOKButton {
-            outputFile = saveDialog.URL!.path
-            NSThread.detachNewThreadSelector(#selector(self.signingThread), toTarget: self, withObject: nil)
+            outputFile = saveDialog.url!.path
+            Thread.detachNewThreadSelector(#selector(self.signingThread), toTarget: self, with: nil)
         } else {
             outputFile = nil
             controlsEnabled(true)
@@ -470,9 +470,9 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         var inputFile = InputFileText.stringValue
         var provisioningFile = self.profileFilename
         let signingCertificate = self.CodesigningCertsPopup.selectedItem?.title
-        let newApplicationID = self.NewApplicationIDTextField.stringValue.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-        let newDisplayName = self.appDisplayName.stringValue.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-        let inputStartsWithHTTP = inputFile.lowercaseString.substringToIndex(inputFile.startIndex.advancedBy(4)) == "http"
+        let newApplicationID = self.NewApplicationIDTextField.stringValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        let newDisplayName = self.appDisplayName.stringValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        let inputStartsWithHTTP = inputFile.lowercased().substring(to: inputFile.characters.index(inputFile.startIndex, offsetBy: 4)) == "http"
         var eggCount: Int = 0
         var continueSigning: Bool? = nil
         
@@ -486,10 +486,10 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         
         // Check if input file exists
         var inputIsDirectory: ObjCBool = false
-        if !inputStartsWithHTTP && !fileManager.fileExistsAtPath(inputFile, isDirectory: &inputIsDirectory){
+        if !inputStartsWithHTTP && !fileManager.fileExists(atPath: inputFile, isDirectory: &inputIsDirectory){
             let alert = NSAlert()
             alert.messageText = "Input file not found"
-            alert.addButtonWithTitle("OK")
+            alert.addButton(withTitle: "OK")
             alert.informativeText = "The file \(inputFile) could not be found"
             alert.runModal()
             controlsEnabled(true)
@@ -515,13 +515,13 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         
         //MARK: Codesign Test
         
-        dispatch_async(dispatch_get_main_queue(), {
+        DispatchQueue.main.async(execute: {
             if let codesignResult = self.testSigning(signingCertificate!, tempFolder: tempFolder) {
                 if codesignResult == false {
                     let alert = NSAlert()
                     alert.messageText = "Codesigning error"
-                    alert.addButtonWithTitle("Yes")
-                    alert.addButtonWithTitle("No")
+                    alert.addButton(withTitle: "Yes")
+                    alert.addButton(withTitle: "No")
                     alert.informativeText = "You appear to have a error with your codesigning certificate, do you want me to try and fix the problem?"
                     let response = alert.runModal()
                     if response == NSAlertFirstButtonReturn {
@@ -529,7 +529,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                         if self.testSigning(signingCertificate!, tempFolder: tempFolder) == false {
                             let errorAlert = NSAlert()
                             errorAlert.messageText = "Unable to Fix"
-                            errorAlert.addButtonWithTitle("OK")
+                            errorAlert.addButton(withTitle: "OK")
                             errorAlert.informativeText = "I was unable to automatically resolve your codesigning issue ☹\n\nIf you have previously trusted your certificate using Keychain, please set the Trust setting back to the system default."
                             errorAlert.runModal()
                             continueSigning = false
@@ -558,7 +558,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         
         //MARK: Create Egg Temp Directory
         do {
-            try fileManager.createDirectoryAtPath(eggDirectory, withIntermediateDirectories: true, attributes: nil)
+            try fileManager.createDirectory(atPath: eggDirectory, withIntermediateDirectories: true, attributes: nil)
         } catch let error as NSError {
             setStatus("Error creating egg temp directory")
             Log.write(error.localizedDescription)
@@ -571,12 +571,12 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         downloadPath = tempFolder.stringByAppendingPathComponent("download.\(inputFile.pathExtension)")
         
         if inputStartsWithHTTP {
-            let defaultConfigObject = NSURLSessionConfiguration.defaultSessionConfiguration()
-            let defaultSession = NSURLSession(configuration: defaultConfigObject, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
-            if let url = NSURL(string: inputFile) {
+            let defaultConfigObject = URLSessionConfiguration.default
+            let defaultSession = Foundation.URLSession(configuration: defaultConfigObject, delegate: self, delegateQueue: OperationQueue.main)
+            if let url = URL(string: inputFile) {
                 downloading = true
                 
-                let downloadTask = defaultSession.downloadTaskWithURL(url)
+                let downloadTask = defaultSession.downloadTask(with: url)
                 setStatus("Downloading file")
                 downloadProgress.startAnimation(nil)
                 downloadTask.resume()
@@ -587,7 +587,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 usleep(100000)
             }
             if downloadError != nil {
-                setStatus("Error downloading file, \(downloadError!.localizedDescription.lowercaseString)")
+                setStatus("Error downloading file, \(downloadError!.localizedDescription.lowercased())")
                 cleanup(tempFolder); return
             } else {
                 inputFile = downloadPath
@@ -595,16 +595,16 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
         
         //MARK: Process input file
-        switch(inputFile.pathExtension.lowercaseString){
+        switch(inputFile.pathExtension.lowercased()){
         case "deb":
             //MARK: --Unpack deb
             let debPath = tempFolder.stringByAppendingPathComponent("deb")
             do {
                 
-                try fileManager.createDirectoryAtPath(debPath, withIntermediateDirectories: true, attributes: nil)
-                try fileManager.createDirectoryAtPath(workingDirectory, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: debPath, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true, attributes: nil)
                 setStatus("Extracting deb file")
-                let debTask = NSTask().execute(arPath, workingDirectory: debPath, arguments: ["-x", inputFile])
+                let debTask = Process().execute(arPath, workingDirectory: debPath, arguments: ["-x", inputFile])
                 Log.write(debTask.output)
                 if debTask.status != 0 {
                     setStatus("Error processing deb file")
@@ -614,10 +614,10 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 var tarUnpacked = false
                 for tarFormat in ["tar","tar.gz","tar.bz2","tar.lzma","tar.xz"]{
                     let dataPath = debPath.stringByAppendingPathComponent("data.\(tarFormat)")
-                    if fileManager.fileExistsAtPath(dataPath){
+                    if fileManager.fileExists(atPath: dataPath){
                         
                         setStatus("Unpacking data.\(tarFormat)")
-                        let tarTask = NSTask().execute(tarPath, workingDirectory: debPath, arguments: ["-xf",dataPath])
+                        let tarTask = Process().execute(tarPath, workingDirectory: debPath, arguments: ["-xf",dataPath])
                         Log.write(tarTask.output)
                         if tarTask.status == 0 {
                             tarUnpacked = true
@@ -629,7 +629,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                     setStatus("Error unpacking data.tar")
                     cleanup(tempFolder); return
                 }
-                try fileManager.moveItemAtPath(debPath.stringByAppendingPathComponent("Applications"), toPath: payloadDirectory)
+                try fileManager.moveItem(atPath: debPath.stringByAppendingPathComponent("Applications"), toPath: payloadDirectory)
                 
             } catch {
                 setStatus("Error processing deb file")
@@ -640,7 +640,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         case "ipa":
             //MARK: --Unzip ipa
             do {
-                try fileManager.createDirectoryAtPath(workingDirectory, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true, attributes: nil)
                 setStatus("Extracting ipa file")
                 
                 let unzipTask = self.unzip(inputFile, outputPath: workingDirectory)
@@ -656,14 +656,14 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             
         case "app":
             //MARK: --Copy app bundle
-            if !inputIsDirectory {
+            if !inputIsDirectory.boolValue {
                 setStatus("Unsupported input file")
                 cleanup(tempFolder); return
             }
             do {
-                try fileManager.createDirectoryAtPath(payloadDirectory, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: payloadDirectory, withIntermediateDirectories: true, attributes: nil)
                 setStatus("Copying app to payload directory")
-                try fileManager.copyItemAtPath(inputFile, toPath: payloadDirectory.stringByAppendingPathComponent(inputFile.lastPathComponent))
+                try fileManager.copyItem(atPath: inputFile, toPath: payloadDirectory.stringByAppendingPathComponent(inputFile.lastPathComponent))
             } catch {
                 setStatus("Error copying app to payload directory")
                 cleanup(tempFolder); return
@@ -672,14 +672,14 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             
         case "xcarchive":
             //MARK: --Copy app bundle from xcarchive
-            if !inputIsDirectory {
+            if !inputIsDirectory.boolValue {
                 setStatus("Unsupported input file")
                 cleanup(tempFolder); return
             }
             do {
-                try fileManager.createDirectoryAtPath(workingDirectory, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: workingDirectory, withIntermediateDirectories: true, attributes: nil)
                 setStatus("Copying app to payload directory")
-                try fileManager.copyItemAtPath(inputFile.stringByAppendingPathComponent("Products/Applications/"), toPath: payloadDirectory)
+                try fileManager.copyItem(atPath: inputFile.stringByAppendingPathComponent("Products/Applications/"), toPath: payloadDirectory)
             } catch {
                 setStatus("Error copying app to payload directory")
                 cleanup(tempFolder); return
@@ -691,36 +691,36 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             cleanup(tempFolder); return
         }
         
-        if !fileManager.fileExistsAtPath(payloadDirectory){
+        if !fileManager.fileExists(atPath: payloadDirectory){
             setStatus("Payload directory doesn't exist")
             cleanup(tempFolder); return
         }
         
         // Loop through app bundles in payload directory
         do {
-            let files = try fileManager.contentsOfDirectoryAtPath(payloadDirectory)
+            let files = try fileManager.contentsOfDirectory(atPath: payloadDirectory)
             var isDirectory: ObjCBool = true
             
             for file in files {
                 
-                fileManager.fileExistsAtPath(payloadDirectory.stringByAppendingPathComponent(file), isDirectory: &isDirectory)
-                if !isDirectory { continue }
+                fileManager.fileExists(atPath: payloadDirectory.stringByAppendingPathComponent(file), isDirectory: &isDirectory)
+                if !isDirectory.boolValue { continue }
                 
                 //MARK: Bundle variables setup
                 let appBundlePath = payloadDirectory.stringByAppendingPathComponent(file)
                 let appBundleInfoPlist = appBundlePath.stringByAppendingPathComponent("Info.plist")
                 let appBundleProvisioningFilePath = appBundlePath.stringByAppendingPathComponent("embedded.mobileprovision")
-                let useAppBundleProfile = (provisioningFile == nil && fileManager.fileExistsAtPath(appBundleProvisioningFilePath))
+                let useAppBundleProfile = (provisioningFile == nil && fileManager.fileExists(atPath: appBundleProvisioningFilePath))
                 
                 //MARK: Delete CFBundleResourceSpecification from Info.plist
-                Log.write(NSTask().execute(defaultsPath, workingDirectory: nil, arguments: ["delete",appBundleInfoPlist,"CFBundleResourceSpecification"]).output)
+                Log.write(Process().execute(defaultsPath, workingDirectory: nil, arguments: ["delete",appBundleInfoPlist,"CFBundleResourceSpecification"]).output)
                 
                 //MARK: Copy Provisioning Profile
                 if provisioningFile != nil {
-                    if fileManager.fileExistsAtPath(appBundleProvisioningFilePath) {
+                    if fileManager.fileExists(atPath: appBundleProvisioningFilePath) {
                         setStatus("Deleting embedded.mobileprovision")
                         do {
-                            try fileManager.removeItemAtPath(appBundleProvisioningFilePath)
+                            try fileManager.removeItem(atPath: appBundleProvisioningFilePath)
                         } catch let error as NSError {
                             setStatus("Error deleting embedded.mobileprovision")
                             Log.write(error.localizedDescription)
@@ -729,7 +729,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                     }
                     setStatus("Copying provisioning profile to app bundle")
                     do {
-                        try fileManager.copyItemAtPath(provisioningFile!, toPath: appBundleProvisioningFilePath)
+                        try fileManager.copyItem(atPath: provisioningFile!, toPath: appBundleProvisioningFilePath)
                     } catch let error as NSError {
                         setStatus("Error copying provisioning profile")
                         Log.write(error.localizedDescription)
@@ -746,7 +746,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                             Log.write("–––––––––––––––––––––––\n\(entitlements)")
                             Log.write("–––––––––––––––––––––––")
                             do {
-                                try entitlements.writeToFile(entitlementsPlist, atomically: false, encoding: NSUTF8StringEncoding)
+                                try entitlements.write(toFile: entitlementsPlist, atomically: false, encoding: String.Encoding.utf8.rawValue as UInt)
                                 setStatus("Saved entitlements to \(entitlementsPlist)")
                             } catch let error as NSError {
                                 setStatus("Error writing entitlements.plist, \(error.localizedDescription)")
@@ -768,21 +768,21 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 
                 //MARK: Make sure that the executable is well... executable.
                 if let bundleExecutable = getPlistKey(appBundleInfoPlist, keyName: "CFBundleExecutable"){
-                    NSTask().execute(chmodPath, workingDirectory: nil, arguments: ["755", appBundlePath.stringByAppendingPathComponent(bundleExecutable)])
+                    Process().execute(chmodPath, workingDirectory: nil, arguments: ["755", appBundlePath.stringByAppendingPathComponent(bundleExecutable)])
                 }
                 
                 //MARK: Change Application ID
                 if newApplicationID != "" {
                     
                     if let oldAppID = getPlistKey(appBundleInfoPlist, keyName: "CFBundleIdentifier") {
-                        func changeAppexID(appexFile: String){
+                        func changeAppexID(_ appexFile: String){
                             let appexPlist = appexFile.stringByAppendingPathComponent("Info.plist")
                             if let appexBundleID = getPlistKey(appexPlist, keyName: "CFBundleIdentifier"){
-                                let newAppexID = "\(newApplicationID)\(appexBundleID.substringFromIndex(oldAppID.endIndex))"
+                                let newAppexID = "\(newApplicationID)\(appexBundleID.substring(from: oldAppID.endIndex))"
                                 setStatus("Changing \(appexFile) id to \(newAppexID)")
                                 setPlistKey(appexPlist, keyName: "CFBundleIdentifier", value: newAppexID)
                             }
-                            if NSTask().execute(defaultsPath, workingDirectory: nil, arguments: ["read", appexPlist,"WKCompanionAppBundleIdentifier"]).status == 0 {
+                            if Process().execute(defaultsPath, workingDirectory: nil, arguments: ["read", appexPlist,"WKCompanionAppBundleIdentifier"]).status == 0 {
                                 setPlistKey(appexPlist, keyName: "WKCompanionAppBundleIdentifier", value: newApplicationID)
                             }
                             recursiveDirectorySearch(appexFile, extensions: ["app"], found: changeAppexID)
@@ -804,7 +804,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 //MARK: Change Display Name
                 if newDisplayName != "" {
                     setStatus("Changing Display Name to \(newDisplayName))")
-                    let displayNameChangeTask = NSTask().execute(defaultsPath, workingDirectory: nil, arguments: ["write",appBundleInfoPlist,"CFBundleDisplayName", newDisplayName])
+                    let displayNameChangeTask = Process().execute(defaultsPath, workingDirectory: nil, arguments: ["write",appBundleInfoPlist,"CFBundleDisplayName", newDisplayName])
                     if displayNameChangeTask.status != 0 {
                         setStatus("Error changing display name")
                         Log.write(displayNameChangeTask.output)
@@ -813,25 +813,25 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 }
                 
                 
-                func generateFileSignFunc(payloadDirectory:String, entitlementsPath: String, signingCertificate: String)->((file:String)->Void){
+                func generateFileSignFunc(_ payloadDirectory:String, entitlementsPath: String, signingCertificate: String)->((_ file:String)->Void){
                     
                     
                     let useEntitlements: Bool = ({
-                        if fileManager.fileExistsAtPath(entitlementsPath) {
+                        if fileManager.fileExists(atPath: entitlementsPath) {
                             return true
                         }
                         return false
                     })()
                     
-                    func shortName(file: String, payloadDirectory: String)->String{
-                        return file.substringFromIndex(payloadDirectory.endIndex)
+                    func shortName(_ file: String, payloadDirectory: String)->String{
+                        return file.substring(from: payloadDirectory.endIndex)
                     }
                     
-                    func beforeFunc(file: String, certificate: String, entitlements: String?){
+                    func beforeFunc(_ file: String, certificate: String, entitlements: String?){
                             setStatus("Codesigning \(shortName(file, payloadDirectory: payloadDirectory))\(useEntitlements ? " with entitlements":"")")
                     }
                     
-                    func afterFunc(file: String, certificate: String, entitlements: String?, codesignOutput: AppSignerTaskOutput){
+                    func afterFunc(_ file: String, certificate: String, entitlements: String?, codesignOutput: AppSignerTaskOutput){
                         if codesignOutput.status != 0 {
                             setStatus("Error codesigning \(shortName(file, payloadDirectory: payloadDirectory))")
                             Log.write(codesignOutput.output)
@@ -839,7 +839,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                         }
                     }
                     
-                    func output(file:String){
+                    func output(_ file:String){
                         codeSign(file, certificate: signingCertificate, entitlements: entitlementsPath, before: beforeFunc, after: afterFunc)
                     }
                     return output
@@ -850,11 +850,11 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 
                 //MARK: Codesigning - Eggs
                 let eggSigningFunction = generateFileSignFunc(eggDirectory, entitlementsPath: entitlementsPlist, signingCertificate: signingCertificate!)
-                func signEgg(eggFile: String){
+                func signEgg(_ eggFile: String){
                     eggCount += 1
                     
                     let currentEggPath = eggDirectory.stringByAppendingPathComponent("egg\(eggCount)")
-                    let shortName = eggFile.substringFromIndex(payloadDirectory.endIndex)
+                    let shortName = eggFile.substring(from: payloadDirectory.endIndex)
                     setStatus("Extracting \(shortName)")
                     if self.unzip(eggFile, outputPath: currentEggPath).status != 0 {
                         Log.write("Error extracting \(shortName)")
@@ -873,16 +873,16 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
                 
                 
                 recursiveDirectorySearch(appBundlePath, extensions: signableExtensions, found: signingFunction)
-                signingFunction(file: appBundlePath)
+                signingFunction(appBundlePath)
                 
                 //MARK: Codesigning - Verification
-                let verificationTask = NSTask().execute(codesignPath, workingDirectory: nil, arguments: ["-v",appBundlePath])
+                let verificationTask = Process().execute(codesignPath, workingDirectory: nil, arguments: ["-v",appBundlePath])
                 if verificationTask.status != 0 {
                     let alert = NSAlert()
-                    alert.addButtonWithTitle("OK")
+                    alert.addButton(withTitle: "OK")
                     alert.messageText = "Error verifying code signature!"
                     alert.informativeText = verificationTask.output
-                    alert.alertStyle = .CriticalAlertStyle
+                    alert.alertStyle = .critical
                     alert.runModal()
                     setStatus("Error verifying code signature")
                     Log.write(verificationTask.output)
@@ -893,13 +893,14 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             setStatus("Error listing files in payload directory")
             Log.write(error.localizedDescription)
             cleanup(tempFolder); return
+        } catch {
         }
-        
+
         //MARK: Packaging
         //Check if output already exists and delete if so
-        if fileManager.fileExistsAtPath(outputFile!) {
+        if fileManager.fileExists(atPath: outputFile!) {
             do {
-                try fileManager.removeItemAtPath(outputFile!)
+                try fileManager.removeItem(atPath: outputFile!)
             } catch let error as NSError {
                 setStatus("Error deleting output file")
                 Log.write(error.localizedDescription)
@@ -918,13 +919,13 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
 
     
     //MARK: IBActions
-    @IBAction func chooseProvisioningProfile(sender: NSPopUpButton) {
+    @IBAction func chooseProvisioningProfile(_ sender: NSPopUpButton) {
         
         switch(sender.indexOfSelectedItem){
         case 0:
             self.profileFilename = nil
-            if NewApplicationIDTextField.enabled == false {
-                NewApplicationIDTextField.enabled = true
+            if NewApplicationIDTextField.isEnabled == false {
+                NewApplicationIDTextField.isEnabled = true
                 NewApplicationIDTextField.stringValue = ""
             }
             break
@@ -937,17 +938,17 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
             openDialog.allowsOtherFileTypes = false
             openDialog.allowedFileTypes = ["mobileprovision"]
             openDialog.runModal()
-            if let filename = openDialog.URLs.first,
-                   profileFilename = filename.path {
-                checkProfileID(ProvisioningProfile(filename: profileFilename))
+            if let filename = openDialog.urls.first,
+               filename.absoluteString.characters.count > 0  {
+                checkProfileID(ProvisioningProfile(filename: filename.path))
             } else {
-                sender.selectItemAtIndex(0)
+                sender.selectItem(at: 0)
                 chooseProvisioningProfile(sender)
             }
             break
             
         case 2:
-            sender.selectItemAtIndex(0)
+            sender.selectItem(at: 0)
             chooseProvisioningProfile(sender)
             break
             
@@ -958,7 +959,7 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         }
         
     }
-    @IBAction func doBrowse(sender: AnyObject) {
+    @IBAction func doBrowse(_ sender: AnyObject) {
         let openDialog = NSOpenPanel()
         openDialog.canChooseFiles = true
         openDialog.canChooseDirectories = false
@@ -966,31 +967,31 @@ class MainView: NSView, NSURLSessionDataDelegate, NSURLSessionDelegate, NSURLSes
         openDialog.allowsOtherFileTypes = false
         openDialog.allowedFileTypes = ["ipa","IPA","deb","DEB","app","APP","xcarchive","XCARCHIVE"]
         openDialog.runModal()
-        if let filename = openDialog.URLs.first {
-            InputFileText.stringValue = filename.path!
+        if let filename = openDialog.urls.first {
+            InputFileText.stringValue = filename.path
         }
     }
-    @IBAction func chooseSigningCertificate(sender: NSPopUpButton) {
+    @IBAction func chooseSigningCertificate(_ sender: NSPopUpButton) {
         Log.write("Set Codesigning Certificate Default to: \(sender.stringValue)")
         defaults.setValue(sender.selectedItem?.title, forKey: "signingCertificate")
     }
     
-    @IBAction func doSign(sender: NSButton) {
+    @IBAction func doSign(_ sender: NSButton) {
         switch(true){
             case (codesigningCerts.count == 0):
                 showCodesignCertsErrorAlert()
                 break
             
             default:
-                NSApplication.sharedApplication().windows[0].makeFirstResponder(self)
+                NSApplication.shared().windows[0].makeFirstResponder(self)
                 startSigning()
         }
     }
     
-    @IBAction func statusLabelClick(sender: NSButton) {
+    @IBAction func statusLabelClick(_ sender: NSButton) {
         if let outputFile = self.outputFile {
-            if fileManager.fileExistsAtPath(outputFile) {
-                NSWorkspace.sharedWorkspace().activateFileViewerSelectingURLs([NSURL(fileURLWithPath: outputFile)])
+            if fileManager.fileExists(atPath: outputFile) {
+                NSWorkspace.shared().activateFileViewerSelecting([URL(fileURLWithPath: outputFile)])
             }
         }
     }

--- a/AppSigner/Updates.xib
+++ b/AppSigner/Updates.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="UpdatesController" customModule="iOS_App_Signer" customModuleProvider="target">
@@ -64,15 +65,13 @@
                             <rect key="frame" x="1" y="1" width="501" height="198"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" allowsNonContiguousLayout="YES" id="9oR-gz-UUY">
+                                <textView editable="NO" importsGraphics="NO" allowsNonContiguousLayout="YES" id="9oR-gz-UUY">
                                     <rect key="frame" x="0.0" y="0.0" width="501" height="198"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <size key="minSize" width="501" height="198"/>
                                     <size key="maxSize" width="503" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="501" height="198"/>
-                                    <size key="maxSize" width="503" height="10000000"/>
                                 </textView>
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/AppSigner/UpdatesController.swift
+++ b/AppSigner/UpdatesController.swift
@@ -34,7 +34,7 @@ class UpdatesController: NSWindowController {
         configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         let session = URLSession(configuration: configuration)
 
-        let task = session.dataTask(with: urlRequest as! URLRequest, completionHandler: {
+        let task = session.dataTask(with: urlRequest as URLRequest, completionHandler: {
             (data, response, error) -> Void in
 
             if error == nil {
@@ -63,11 +63,11 @@ class UpdatesController: NSWindowController {
                                         updatesWindow!.showWindow([currentVersion,releases])
                                     }
                                     if let statusFunc = callbackFunc {
-                                        statusFunc(true, data, response, error as! NSError)
+                                        statusFunc(true, data, response, error as? NSError)
                                     }
                                 } else {
                                     if let statusFunc = callbackFunc {
-                                        statusFunc(false, data, response, error as! NSError)
+                                        statusFunc(false, data, response, error as? NSError)
                                     }
                                 }
                         }
@@ -76,12 +76,12 @@ class UpdatesController: NSWindowController {
                     }
                 } else {
                     if let statusFunc = callbackFunc {
-                        statusFunc(false, data, response, error as! NSError)
+                        statusFunc(false, data, response, error as? NSError)
                     }
                 }
             } else {
                 if let statusFunc = callbackFunc {
-                    statusFunc(false, data, response, error as! NSError)
+                    statusFunc(false, data, response, error as? NSError)
                 }
             }
         })

--- a/AppSigner/UpdatesController.swift
+++ b/AppSigner/UpdatesController.swift
@@ -12,7 +12,7 @@ class UpdatesController: NSWindowController {
     //MARK: Variables
     let markdownParser = NSAttributedStringMarkdownParser()
     var latestVersion: String?
-    let prefs = NSUserDefaults.standardUserDefaults()
+    let prefs = UserDefaults.standard
     static var updatesWindow: UpdatesController?
     
     //MARK: IBOutlets
@@ -23,39 +23,39 @@ class UpdatesController: NSWindowController {
     
     //MARK: Functions
     static func checkForUpdate(
-        currentVersion: String = NSBundle.mainBundle().infoDictionary!["CFBundleShortVersionString"] as! String,
+        _ currentVersion: String = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String,
         forceShow: Bool = false,
-        callbackFunc: ((status: Bool, data: NSData?, response: NSURLResponse?, error: NSError?)->Void)? = nil
+        callbackFunc: ((_ status: Bool, _ data: Data?, _ response: URLResponse?, _ error: NSError?)->Void)? = nil
     ) {
-        let requestURL: NSURL = NSURL(string: "https://api.github.com/repos/DanTheMan827/ios-app-signer/releases")!
-        let urlRequest: NSMutableURLRequest = NSMutableURLRequest(URL: requestURL)
+        let requestURL: URL = URL(string: "https://api.github.com/repos/DanTheMan827/ios-app-signer/releases")!
+        let urlRequest: NSMutableURLRequest = NSMutableURLRequest(url: requestURL)
         
-        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
-        configuration.requestCachePolicy = .ReloadIgnoringLocalAndRemoteCacheData
-        let session = NSURLSession(configuration: configuration)
-        
-        let task = session.dataTaskWithRequest(urlRequest) {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let session = URLSession(configuration: configuration)
+
+        let task = session.dataTask(with: urlRequest as! URLRequest, completionHandler: {
             (data, response, error) -> Void in
-            
+
             if error == nil {
-                let httpResponse = response as! NSHTTPURLResponse
+                let httpResponse = response as! HTTPURLResponse
                 let statusCode = httpResponse.statusCode
-                
+
                 if (statusCode == 200) {
                     do{
-                        
-                        let json = try NSJSONSerialization.JSONObjectWithData(data!, options:.AllowFragments)
+
+                        let json = try JSONSerialization.jsonObject(with: data!, options:.allowFragments)
                         if let releases = json as? [[String: AnyObject]],
-                            release = releases[0] as? [String: AnyObject],
-                            name = release["name"] as? String {
-                                let prefs = NSUserDefaults.standardUserDefaults()
-                                if let skipVersion = prefs.stringForKey("skipVersion"){
+                            let release = releases[0] as? [String: AnyObject],
+                            let name = release["name"] as? String {
+                                let prefs = UserDefaults.standard
+                                if let skipVersion = prefs.string(forKey: "skipVersion"){
                                     if skipVersion == name && forceShow == false {
                                         return
                                     }
                                 }
                                 if name != currentVersion {
-                                    dispatch_async(dispatch_get_main_queue()) {
+                                    DispatchQueue.main.async {
                                         // update some UI
                                         if updatesWindow == nil {
                                             updatesWindow = UpdatesController(windowNibName: "Updates")
@@ -63,11 +63,11 @@ class UpdatesController: NSWindowController {
                                         updatesWindow!.showWindow([currentVersion,releases])
                                     }
                                     if let statusFunc = callbackFunc {
-                                        statusFunc(status: true, data: data, response: response, error: error)
+                                        statusFunc(true, data, response, error as! NSError)
                                     }
                                 } else {
                                     if let statusFunc = callbackFunc {
-                                        statusFunc(status: false, data: data, response: response, error: error)
+                                        statusFunc(false, data, response, error as! NSError)
                                     }
                                 }
                         }
@@ -76,17 +76,17 @@ class UpdatesController: NSWindowController {
                     }
                 } else {
                     if let statusFunc = callbackFunc {
-                        statusFunc(status: false, data: data, response: response, error: error)
+                        statusFunc(false, data, response, error as! NSError)
                     }
                 }
             } else {
                 if let statusFunc = callbackFunc {
-                    statusFunc(status: false, data: data, response: response, error: error)
+                    statusFunc(false, data, response, error as! NSError)
                 }
             }
-        }
-        
-        
+        })
+
+
         task.resume()
         
     }
@@ -98,16 +98,16 @@ class UpdatesController: NSWindowController {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    override func showWindow(sender: AnyObject?) {
+    override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        appIcon.image = NSWorkspace.sharedWorkspace().iconForFile(NSBundle.mainBundle().bundlePath)
+        appIcon.image = NSWorkspace.shared().icon(forFile: Bundle.main.bundlePath)
         var releaseOutput: [String] = []
         if let senderArray = sender as? [AnyObject] {
             if let releases = senderArray[1] as? [[String: AnyObject]],
-                currentVersion = senderArray[0] as? String {
+                let currentVersion = senderArray[0] as? String {
                 for release in releases {
                     if let name = release["name"] as? String,
-                        body = release["body"] as? String {
+                        let body = release["body"] as? String {
                         if latestVersion == nil {
                             latestVersion = name
                         }
@@ -119,28 +119,28 @@ class UpdatesController: NSWindowController {
                 }
                 versionLabel.stringValue = "Version \(latestVersion!) is now available, you have \(currentVersion)."
             }
-            setChangelog(releaseOutput.joinWithSeparator("\n\n"))
+            setChangelog(releaseOutput.joined(separator: "\n\n"))
         }
         
     }
-    func setChangelog(text: String){
-        changelogText.editable = true
+    func setChangelog(_ text: String){
+        changelogText.isEditable = true
         changelogText.string = ""
-        changelogText.insertText(markdownParser.attributedStringFromMarkdownString(text))
-        changelogText.editable = false
+        changelogText.insertText(markdownParser.attributedString(fromMarkdownString: text))
+        changelogText.isEditable = false
     }
     
     //MARK: IBActions
-    @IBAction func skipVersion(sender: NSButton) {
+    @IBAction func skipVersion(_ sender: NSButton) {
         prefs.setValue(latestVersion, forKey: "skipVersion")
         updateWindow.close()
     }
-    @IBAction func remindMeLater(sender: NSButton) {
+    @IBAction func remindMeLater(_ sender: NSButton) {
         prefs.setValue(nil, forKey: "skipVersion")
         updateWindow.close()
     }
-    @IBAction func visitProjectPage(sender: NSButton) {
-        NSWorkspace.sharedWorkspace().openURL(NSURL(string: "http://dantheman827.github.io/ios-app-signer/")!)
+    @IBAction func visitProjectPage(_ sender: NSButton) {
+        NSWorkspace.shared().open(URL(string: "http://dantheman827.github.io/ios-app-signer/")!)
         updateWindow.close()
     }
 }

--- a/Log.swift
+++ b/Log.swift
@@ -8,23 +8,23 @@
 
 import Foundation
 class Log {
-    static let mainBundle = NSBundle.mainBundle()
+    static let mainBundle = Bundle.main
     static let bundleID = mainBundle.bundleIdentifier
     static let bundleName = mainBundle.infoDictionary!["CFBundleName"]
     static let bundleVersion = mainBundle.infoDictionary!["CFBundleShortVersionString"]
     static let tempDirectory = NSTemporaryDirectory()
-    static var logName = Log.tempDirectory.stringByAppendingPathComponent("\(Log.bundleID!)-\(NSDate().timeIntervalSince1970).log")
+    static var logName = Log.tempDirectory.stringByAppendingPathComponent("\(Log.bundleID!)-\(Date().timeIntervalSince1970).log")
     
-    static func write(value:String) {
-        let formatter = NSDateFormatter()
+    static func write(_ value:String) {
+        let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         
         
-        if let outputStream = NSOutputStream(toFileAtPath: logName, append: true) {
+        if let outputStream = OutputStream(toFileAtPath: logName, append: true) {
             outputStream.open()
-            let text = "\(formatter.stringFromDate(NSDate())) \(value)\n"
-            let data = text.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
-            outputStream.write(UnsafePointer(data.bytes), maxLength: data.length)
+            let text = "\(formatter.string(from: Date())) \(value)\n"
+            let data = text.data(using: String.Encoding.utf8, allowLossyConversion: false)!
+            outputStream.write((data as NSData).bytes.bindMemory(to: UInt8.self, capacity: data.count), maxLength: data.count)
             outputStream.close()
         }
         NSLog(value)

--- a/NSTask-execute.swift
+++ b/NSTask-execute.swift
@@ -15,27 +15,27 @@ struct AppSignerTaskOutput {
         self.output = output
     }
 }
-extension NSTask {
+extension Process {
     func launchSyncronous() -> AppSignerTaskOutput {
-        self.standardInput = NSFileHandle.fileHandleWithNullDevice()
-        let pipe = NSPipe()
+        self.standardInput = FileHandle.nullDevice
+        let pipe = Pipe()
         self.standardOutput = pipe
         self.standardError = pipe
         let pipeFile = pipe.fileHandleForReading
         self.launch()
         
         let data = NSMutableData()
-        while self.running {
-            data.appendData(pipeFile.availableData)
+        while self.isRunning {
+            data.append(pipeFile.availableData)
         }
         
-        let output = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+        let output = NSString(data: data as Data, encoding: String.Encoding.utf8.rawValue) as! String
         
         return AppSignerTaskOutput(status: self.terminationStatus, output: output)
         
     }
     
-    func execute(launchPath: String, workingDirectory: String?, arguments: [String]?)->AppSignerTaskOutput{
+    func execute(_ launchPath: String, workingDirectory: String?, arguments: [String]?)->AppSignerTaskOutput{
         self.launchPath = launchPath
         if arguments != nil {
             self.arguments = arguments

--- a/ProvisioningProfile.swift
+++ b/ProvisioningProfile.swift
@@ -11,26 +11,26 @@ import AppKit
 struct ProvisioningProfile {
     var filename: String,
         name: String,
-        created:NSDate,
-        expires: NSDate,
+        created:Date,
+        expires: Date,
         appID: String,
         teamID: String,
         rawXML: String,
         entitlements: AnyObject?
-    private let delegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    fileprivate let delegate = NSApplication.shared().delegate as! AppDelegate
     
     static func getProfiles() -> [ProvisioningProfile] {
         var output: [ProvisioningProfile] = []
         
-        let fileManager = NSFileManager()
-        if let libraryDirectory = fileManager.URLsForDirectory(.LibraryDirectory, inDomains: .UserDomainMask).first,
-            libraryPath = libraryDirectory.path {
-                let provisioningProfilesPath = libraryPath.stringByAppendingPathComponent("MobileDevice/Provisioning Profiles") as NSString
-                if let provisioningProfiles = try? fileManager.contentsOfDirectoryAtPath(provisioningProfilesPath as String) {
+        let fileManager = FileManager()
+        if let libraryDirectory = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first,
+            libraryDirectory.path.characters.count > 0 {
+                let provisioningProfilesPath = libraryDirectory.path.stringByAppendingPathComponent("MobileDevice/Provisioning Profiles") as NSString
+                if let provisioningProfiles = try? fileManager.contentsOfDirectory(atPath: provisioningProfilesPath as String) {
                     
                     for provFile in provisioningProfiles {
                         if provFile.pathExtension == "mobileprovision" {
-                            let profileFilename = provisioningProfilesPath.stringByAppendingPathComponent(provFile)
+                            let profileFilename = provisioningProfilesPath.appendingPathComponent(provFile)
                             if let profile = ProvisioningProfile(filename: profileFilename) {
                                 output.append(profile)
                             }
@@ -46,29 +46,29 @@ struct ProvisioningProfile {
     init?(filename: String){
         let securityArgs = ["cms","-D","-i", filename]
         
-         let taskOutput = NSTask().execute("/usr/bin/security", workingDirectory: nil, arguments: securityArgs)
+         let taskOutput = Process().execute("/usr/bin/security", workingDirectory: nil, arguments: securityArgs)
          if taskOutput.status == 0 {
-            if let xmlIndex = taskOutput.output.rangeOfString("<?xml") {
-                self.rawXML = taskOutput.output.substringFromIndex(xmlIndex.startIndex)
+            if let xmlIndex = taskOutput.output.range(of: "<?xml") {
+                self.rawXML = taskOutput.output.substring(from: xmlIndex.lowerBound)
             } else {
                 Log.write("Unable to find xml start tag in profile")
                 self.rawXML = taskOutput.output
             }
             
-            if let results = try? NSPropertyListSerialization.propertyListWithData(self.rawXML.dataUsingEncoding(NSUTF8StringEncoding)!, options: .Immutable, format: nil) {
-                if let expirationDate = results.valueForKey("ExpirationDate") as? NSDate,
-                    creationDate = results.valueForKey("CreationDate") as? NSDate,
-                    name = results.valueForKey("Name") as? String,
-                    entitlements = results.valueForKey("Entitlements"),
-                    applicationIdentifier = entitlements.valueForKey("application-identifier") as? String,
-                    periodIndex = applicationIdentifier.characters.indexOf(".") {
+            if let results = try? PropertyListSerialization.propertyList(from: self.rawXML.data(using: String.Encoding.utf8)!, options: PropertyListSerialization.MutabilityOptions(), format: nil) {
+                if let expirationDate = (results as AnyObject).value(forKey: "ExpirationDate") as? Date,
+                    let creationDate = (results as AnyObject).value(forKey: "CreationDate") as? Date,
+                    let name = (results as AnyObject).value(forKey: "Name") as? String,
+                    let entitlements = (results as AnyObject).value(forKey: "Entitlements"),
+                    let applicationIdentifier = (entitlements as AnyObject).value(forKey: "application-identifier") as? String,
+                    let periodIndex = applicationIdentifier.characters.index(of: ".") {
                         self.filename = filename
                         self.expires = expirationDate
                         self.created = creationDate
-                        self.appID = applicationIdentifier.substringFromIndex(periodIndex.advancedBy(1))
-                        self.teamID = applicationIdentifier.substringToIndex(periodIndex)
+                        self.appID = applicationIdentifier.substring(from: applicationIdentifier.index(periodIndex, offsetBy: 1))
+                        self.teamID = applicationIdentifier.substring(to: periodIndex)
                         self.name = name
-                        self.entitlements = entitlements
+                        self.entitlements = entitlements as AnyObject?
                 } else {
                     Log.write("Error processing \(filename.lastPathComponent)")
                     return nil
@@ -83,13 +83,13 @@ struct ProvisioningProfile {
         }
     }
     
-    func getEntitlementsPlist(tempFolder: String) -> NSString? {
+    func getEntitlementsPlist(_ tempFolder: String) -> NSString? {
         let mobileProvisionPlist = tempFolder.stringByAppendingPathComponent("mobileprovision.plist")
         do {
-            try self.rawXML.writeToFile(mobileProvisionPlist, atomically: false, encoding: NSUTF8StringEncoding)
-            let plistBuddy = NSTask().execute("/usr/libexec/PlistBuddy", workingDirectory: nil, arguments: ["-c", "Print :Entitlements",mobileProvisionPlist, "-x"])
+            try self.rawXML.write(toFile: mobileProvisionPlist, atomically: false, encoding: String.Encoding.utf8)
+            let plistBuddy = Process().execute("/usr/libexec/PlistBuddy", workingDirectory: nil, arguments: ["-c", "Print :Entitlements",mobileProvisionPlist, "-x"])
             if plistBuddy.status == 0 {
-                return plistBuddy.output
+                return plistBuddy.output as NSString
             } else {
                 Log.write("PlistBuddy Failed")
                 Log.write(plistBuddy.output)
@@ -98,6 +98,8 @@ struct ProvisioningProfile {
         } catch let error as NSError {
             Log.write("Error writing mobileprovision.plist")
             Log.write(error.localizedDescription)
+            return nil
+        } catch {
             return nil
         }
     }

--- a/StringByAppendingPathComponent.swift
+++ b/StringByAppendingPathComponent.swift
@@ -26,14 +26,14 @@ extension String {
         
         get {
             
-            return (self as NSString).stringByDeletingLastPathComponent
+            return (self as NSString).deletingLastPathComponent
         }
     }
     var stringByDeletingPathExtension: String {
         
         get {
             
-            return (self as NSString).stringByDeletingPathExtension
+            return (self as NSString).deletingPathExtension
         }
     }
     var pathComponents: [String] {
@@ -44,17 +44,17 @@ extension String {
         }
     }
     
-    func stringByAppendingPathComponent(path: String) -> String {
+    func stringByAppendingPathComponent(_ path: String) -> String {
         
         let nsSt = self as NSString
         
-        return nsSt.stringByAppendingPathComponent(path)
+        return nsSt.appendingPathComponent(path)
     }
     
-    func stringByAppendingPathExtension(ext: String) -> String? {
+    func stringByAppendingPathExtension(_ ext: String) -> String? {
         
         let nsSt = self as NSString
         
-        return nsSt.stringByAppendingPathExtension(ext)
+        return nsSt.appendingPathExtension(ext)
     }
 }

--- a/iOS App Signer.xcodeproj/project.pbxproj
+++ b/iOS App Signer.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 					652408C71BE743D4006FA4C6 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = 7PM929Z8M2;
+						LastSwiftMigration = 0810;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 0;
@@ -354,6 +355,7 @@
 				PRODUCT_NAME = "iOS App Signer";
 				SWIFT_OBJC_BRIDGING_HEADER = "iOS App Signer-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -369,6 +371,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.DanTheMan827.AppSigner;
 				PRODUCT_NAME = "iOS App Signer";
 				SWIFT_OBJC_BRIDGING_HEADER = "iOS App Signer-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Updating to Swift 3 is probably inevitable. I decided to add functionality to strip UISupportedDevices as I feel that is a primary reason for re-signing applications as opposed to simply installing the originals.