### PR TITLE
Add Support for new deb format

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -691,7 +691,13 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
                     setStatus("Error unpacking data.tar")
                     cleanup(tempFolder); return
                 }
-                try fileManager.moveItem(atPath: debPath.stringByAppendingPathComponent("Applications"), toPath: payloadDirectory)
+              
+              var sourcePath = debPath.stringByAppendingPathComponent("Applications")
+              if fileManager.fileExists(atPath: debPath.stringByAppendingPathComponent("var/mobile/Applications")){
+                sourcePath = debPath.stringByAppendingPathComponent("var/mobile/Applications")
+              }
+              
+                try fileManager.moveItem(atPath: sourcePath, toPath: payloadDirectory)
                 
             } catch {
                 setStatus("Error processing deb file")


### PR DESCRIPTION
Beside the old deb format where Kodi was installed into /Applications also support newer deb formats where Kodi is installed into /var/mobile/Applications (as for the greeng0blin tvos jailbreak).

@DanTheMan827 please do a release with this - its needed for supporting tvos jailbreak with my deb files ...