### PR TITLE
Update MainView.swift

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -810,7 +810,10 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
                     setStatus("Parsing entitlements")
                     
                     if let profile = ProvisioningProfile(filename: useAppBundleProfile ? appBundleProvisioningFilePath : provisioningFile!){
-                        if let entitlements = profile.getEntitlementsPlist(tempFolder) {
+                        if var entitlements = profile.getEntitlementsPlist(tempFolder) {
+                            if let oldAppID = getPlistKey(appBundleInfoPlist, keyName: "CFBundleIdentifier"){
+                                entitlements = entitlements.replacingOccurrences(of: "*", with: oldAppID) as NSString
+                            }
                             Log.write("–––––––––––––––––––––––\n\(entitlements)")
                             Log.write("–––––––––––––––––––––––")
                             do {


### PR DESCRIPTION
Development证书打包时保持跟xcode生成的entitlements.plist文件一致，避免重签名后不能真机调试。

The development certificate is kept consistent with the entitlements.plist file generated by xcode when it is packaged, so that it cannot be debugged after re-signing.