### PR TITLE
Bug Fix: pass the required full path to checkMachOFile

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -376,7 +376,7 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
                     } else {
                         //NSLog("couldnt find: %@", file)
                     }
-                } else if isDirectory.boolValue == false && checkMachOFile(file) {
+                } else if isDirectory.boolValue == false && checkMachOFile(currentFile) {
                     found(currentFile)
                 }
                 


### PR DESCRIPTION
The file parameter was incorrectly passed to checkMachOFile. This bug would cause a file/dylib with no extension to be not properly signed.