### PR TITLE
Use NSDictionary to implement getPlistKey.

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -437,12 +437,8 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
         return "\(size)B"
     }
     @objc func getPlistKey(_ plist: String, keyName: String)->String? {
-        let currTask = Process().execute(defaultsPath, workingDirectory: nil, arguments: ["read", plist, keyName])
-        if currTask.status == 0 {
-            return String(currTask.output.dropLast())
-        } else {
-            return nil
-        }
+        let dictionary = NSDictionary(contentsOfFile: plist);
+        return dictionary?[keyName] as? String
     }
     
     func setPlistKey(_ plist: String, keyName: String, value: String)->AppSignerTaskOutput {


### PR DESCRIPTION
If the value is UTF-8 (e.g. Chinese characters), "defaults read" would escape it. This patch would allow UTF-8 plist values to be read.