### PR TITLE
Add modal if there are duplicate certificates

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -261,8 +261,6 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
         }
         let rawResult = securityResult.output.components(separatedBy: "\"")
         
-        var index: Int
-        
         for index in stride(from: 0, through: rawResult.count - 2, by: 2) {
             if !(rawResult.count - 1 < index + 1) {
                 output.append(rawResult[index+1])

--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -510,6 +510,15 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
         let codesignTask = Process().execute(codesignPath, workingDirectory: nil, arguments: arguments)
         if codesignTask.status != 0 {
             Log.write("Error codesign: \(codesignTask.output)")
+            
+            if (codesignTask.output.contains("ambiguous")) {
+                let alert = NSAlert()
+                alert.messageText = "Codesign failed due to ambiguous certificates"
+                alert.informativeText = "\(codesignTask.output)\nOpen Keychain Access and remove the duplicate certificates."
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
         }
         
         if let afterFunc = after {


### PR DESCRIPTION
This adds a modal if `codesign` reports that there are ambiguous certificates, it's not clear how this happens but it occurs often.

The only fix appears to be removing duplicate certificates in Keychain Access.

Possibly fixes https://github.com/DanTheMan827/ios-app-signer/issues/16#issuecomment-249400778.