### PR TITLE
Fix crash on empty input

### DIFF
--- a/AppSigner/MainView.swift
+++ b/AppSigner/MainView.swift
@@ -543,6 +543,10 @@ class MainView: NSView, URLSessionDataDelegate, URLSessionDelegate, URLSessionDo
     
     @objc func startSigning() {
         let inputFile = InputFileText.stringValue
+        if (inputFile.count < 4) {
+            return
+        }
+        
         if inputFile.pathExtension.lowercased() == "appex" {
             outputFile = inputFile
         } else {


### PR DESCRIPTION
This prevents a crash if the file input is empty or less than 4 characters (which causes parsing `http` to fail).